### PR TITLE
Fix typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -209,7 +209,7 @@
 									<h2>Useful information</h2>
 
 									<p>
-										<strong>For Arch Linux users,</strong> you need to install the <a href="https://aur.archlinux.org/packages/libsndio-61-compat/" target="_blank">lisndio-61-compat</a>.
+										<strong>For Arch Linux users,</strong> you need to install the <a href="https://aur.archlinux.org/packages/libsndio-61-compat/" target="_blank">libsndio-61-compat</a>.
 									</p>
 
 									<p>


### PR DESCRIPTION
I fixed a typo to enable Arch-users to directly install the lib; instead of looking up the real name in the aur.